### PR TITLE
remove unnecesary text and add some improvement styles into inventory

### DIFF
--- a/src/commons/components/Item/Item.js
+++ b/src/commons/components/Item/Item.js
@@ -69,11 +69,12 @@ class Item extends Component {
     const renderTypeItem = resources.getItem(type);
     const box = resources.getBox(disabled);
     if(object.isEmpty(renderTypeItem)) return null;
+    const styleInactiveItem = active ? { opacity: 0.5 } : {};
 
     const source = this.getItemSource(renderTypeItem, active, disabled);
 
     return (
-      <Container source={{uri: box}} resizeMode='contain' width={width}>
+      <Container source={{uri: box}} resizeMode='contain' width={width} style={styleInactiveItem}>
         <TouchableWithoutFeedback onPress={() => this.onPressItem(disabled)}>
           <ItemImageAnimated
             ref={this.handleViewRef}

--- a/src/commons/components/Item/Item.js
+++ b/src/commons/components/Item/Item.js
@@ -24,6 +24,14 @@ const Container = styled(ImageBackground)`
   overflow: hidden;
   width: ${props => props.width};
   height: ${props => getHeightAspectRatio(width, height, props.width)};
+  ${props => {
+      if (props.active) {
+        return css`
+          border: solid 5px #FFFF;
+        `
+      }
+    }
+  }
 `;
 
 const itemWidth = 70;
@@ -69,12 +77,11 @@ class Item extends Component {
     const renderTypeItem = resources.getItem(type);
     const box = resources.getBox(disabled);
     if(object.isEmpty(renderTypeItem)) return null;
-    const styleInactiveItem = active ? { opacity: 0.5 } : {};
 
     const source = this.getItemSource(renderTypeItem, active, disabled);
 
     return (
-      <Container source={{uri: box}} resizeMode='contain' width={width} style={styleInactiveItem}>
+      <Container source={{uri: box}} resizeMode='contain' width={width} active={active}>
         <TouchableWithoutFeedback onPress={() => this.onPressItem(disabled)}>
           <ItemImageAnimated
             ref={this.handleViewRef}

--- a/src/containers/Events/ModalEventDescription.js
+++ b/src/containers/Events/ModalEventDescription.js
@@ -55,11 +55,11 @@ export default class ModalEventDescription extends Component {
           <View style={{ width: this.modalSize.width, height: this.modalSize.height, padding: 5, paddingTop: 10, alignItems: 'center' }}>
             <CloseIcon onPress={onClose} />
             <ContentContainer style={{ width: this.modalSize.width - 25, height: this.modalSize.height - 10 }} colorsMargin={['#344F39', '#344F39']} colorsContent={['#74AD50', '#74AD50']}>
-              <Header bolder>{title}</Header>
+              <Header bolder center style={{ marginTop:5 }}>{title}</Header>
               <View style={{ width: Size.iconSizeEventDescription, height: Size.iconSizeEventDescription, margin: 10 }}>
                 <Image source={{ uri: item.image }} style={{ width: Size.iconSizeEventDescription, height: Size.iconSizeEventDescription }} />
               </View>
-              <Header small ellipsizeMode='tail' numberOfLines={3}>{description}</Header>
+              <Header small ellipsizeMode='tail' numberOfLines={3} center style={{marginLeft:5, marginRight:5}}>{description}</Header>
               {buttonProps &&
               <View style={{flex: 1, justifyContent: 'center'}}>
                 <Button {...buttonProps} style={{minWidth: 70}} />

--- a/src/containers/Inventory/Inventory.js
+++ b/src/containers/Inventory/Inventory.js
@@ -216,7 +216,7 @@ export default class Inventory extends Component {
       }
     }
 
-    this.setState({ isEventModalOpen: true, eventSelected: { ...this.generateFakeEvent(item.name,`${item.description} (Item ${currentStatus.status})`, item.active ? source.source : source.inactive), buttonProps: this.generateButtonProps(currentStatus.textButton, this.updateItem(item)) } });
+    this.setState({ isEventModalOpen: true, eventSelected: { ...this.generateFakeEvent(item.name, item.description, item.active ? source.source : source.inactive), buttonProps: this.generateButtonProps(currentStatus.textButton, this.updateItem(item)) } });
   }
 
   addDisabledAchievements = (currentAchievements = []) => {
@@ -312,8 +312,10 @@ export default class Inventory extends Component {
   _renderEventsItem = ({ item }) => {
     const width = this.itemWidth;
     const box = resources.getBox(!item.completed)
+    const styleInactiveItem = item.completed ? { opacity: 0.5 } : {};
     return (
       <Container
+        style={styleInactiveItem}
         onPress={() => this.setState({ isEventModalOpen: true, eventSelected: item })}
         activeOpacity={0.8}
         width={width}

--- a/src/containers/Inventory/Inventory.js
+++ b/src/containers/Inventory/Inventory.js
@@ -60,12 +60,17 @@ const Container = styled(TouchableOpacity)`
   width: ${props => props.width};
   height: ${props => getHeightAspectRatio(width, height, props.width)};
   ${props => {
-    if (props.inactive) {
-      return css`
-        border: solid 0px #40582D;
-        border-radius: 13px;
-      `}
-  }
+      if (props.inactive) {
+        return css`
+          border: solid 0px #40582D;
+          border-radius: 13px;
+        `
+      }else {
+        return css`
+          border: solid 5px #FFFF;
+        `
+      }
+    }
   }
   overflow: hidden;
 `;
@@ -312,10 +317,8 @@ export default class Inventory extends Component {
   _renderEventsItem = ({ item }) => {
     const width = this.itemWidth;
     const box = resources.getBox(!item.completed)
-    const styleInactiveItem = item.completed ? { opacity: 0.5 } : {};
     return (
       <Container
-        style={styleInactiveItem}
         onPress={() => this.setState({ isEventModalOpen: true, eventSelected: item })}
         activeOpacity={0.8}
         width={width}


### PR DESCRIPTION
Tarea: https://nodriza.shiriculapo.com/issues/1504
Ahora cuando un item esta activo tiene la imagen una ligera opacidad, al igual que en el frontend:
![Captura de Pantalla 2019-07-24 a la(s) 16 19 46](https://user-images.githubusercontent.com/6590748/61829644-03aee400-ae2f-11e9-8e41-d9e7c953092a.png)
Fixeado los margenes y centrado el texto
![Captura de Pantalla 2019-07-24 a la(s) 16 19 55](https://user-images.githubusercontent.com/6590748/61829707-175a4a80-ae2f-11e9-935d-a0c2e9021109.png)
